### PR TITLE
Refactor: Localize error messages and remove unused constants

### DIFF
--- a/app/src/androidTest/java/de/syntax_institut/androidabschlussprojekt/ui/integration/SearchPagingIntegrationTest.kt
+++ b/app/src/androidTest/java/de/syntax_institut/androidabschlussprojekt/ui/integration/SearchPagingIntegrationTest.kt
@@ -249,10 +249,10 @@ class SearchPagingIntegrationTest : KoinTest {
 
         // Then
         composeTestRule.waitUntil(timeoutMillis = 5000) {
-            composeTestRule.onAllNodesWithText("${Constants.ERROR}:")
+            composeTestRule.onAllNodesWithText("Fehler:")
                 .fetchSemanticsNodes().size == 1
         }
-        composeTestRule.onNodeWithText("${Constants.ERROR}:").assertExists()
+        composeTestRule.onNodeWithText("Fehler:").assertExists()
     }
 
     @Test

--- a/app/src/androidTest/java/de/syntax_institut/androidabschlussprojekt/ui/screens/DetailScreenTest.kt
+++ b/app/src/androidTest/java/de/syntax_institut/androidabschlussprojekt/ui/screens/DetailScreenTest.kt
@@ -89,7 +89,7 @@ class DetailScreenTest {
         }
 
         // Then
-        composeTestRule.onNodeWithText("${Constants.ERROR}: Network error").assertExists()
+        composeTestRule.onNodeWithText("Fehler: Network error").assertExists()
     }
 
     @Test

--- a/app/src/main/java/de/syntax_institut/androidabschlussprojekt/data/Constants.kt
+++ b/app/src/main/java/de/syntax_institut/androidabschlussprojekt/data/Constants.kt
@@ -7,8 +7,6 @@ package de.syntax_institut.androidabschlussprojekt.data
 object Constants {
 
     // Allgemeine Fehler-Konstante für Logging und Fehlertexte
-    const val ERROR = "Fehler"
-    const val ERROR_UNKNOWN = "Unbekannter Fehler"
 
     // Datenbanknamen
     const val DATABASE_NAME = "game_database"

--- a/app/src/main/java/de/syntax_institut/androidabschlussprojekt/data/local/mapper/FavoriteGameMapper.kt
+++ b/app/src/main/java/de/syntax_institut/androidabschlussprojekt/data/local/mapper/FavoriteGameMapper.kt
@@ -29,7 +29,7 @@ object FavoriteGameMapper {
         } catch (e: Exception) {
             AppLogger.e(
                 "FavoriteGameMapper",
-                "${Constants.ERROR} beim Parsen der String-Liste: ${e.localizedMessage}",
+                "Fehler beim Parsen der String-Liste: ${e.localizedMessage}",
                 e
             )
             emptyList()
@@ -41,7 +41,7 @@ object FavoriteGameMapper {
         } catch (e: Exception) {
             AppLogger.e(
                 "FavoriteGameMapper",
-                "${Constants.ERROR} beim Parsen der Movie-Liste: ${e.localizedMessage}",
+                "Fehler beim Parsen der Movie-Liste: ${e.localizedMessage}",
                 e
             )
             emptyList()
@@ -53,7 +53,7 @@ object FavoriteGameMapper {
         } catch (e: Exception) {
             AppLogger.e(
                 "FavoriteGameMapper",
-                "${Constants.ERROR} beim Serialisieren der String-Liste: ${e.localizedMessage}",
+                "Fehler beim Serialisieren der String-Liste: ${e.localizedMessage}",
                 e
             )
             Constants.EMPTY_JSON_ARRAY
@@ -65,7 +65,7 @@ object FavoriteGameMapper {
         } catch (e: Exception) {
             AppLogger.e(
                 "FavoriteGameMapper",
-                "${Constants.ERROR} beim Serialisieren der Movie-Liste: ${e.localizedMessage}",
+                "Fehler beim Serialisieren der Movie-Liste: ${e.localizedMessage}",
                 e
             )
             Constants.EMPTY_JSON_ARRAY

--- a/app/src/main/java/de/syntax_institut/androidabschlussprojekt/data/repositories/FavoritesRepository.kt
+++ b/app/src/main/java/de/syntax_institut/androidabschlussprojekt/data/repositories/FavoritesRepository.kt
@@ -2,7 +2,6 @@ package de.syntax_institut.androidabschlussprojekt.data.repositories
 
 import com.squareup.moshi.*
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
-import de.syntax_institut.androidabschlussprojekt.data.*
 import de.syntax_institut.androidabschlussprojekt.data.local.dao.*
 import de.syntax_institut.androidabschlussprojekt.data.local.mapper.FavoriteGameMapper.toFavoriteEntity
 import de.syntax_institut.androidabschlussprojekt.data.local.mapper.FavoriteGameMapper.toGame
@@ -62,7 +61,7 @@ class FavoritesRepository @Inject constructor(
                 } catch (e: Exception) {
                     AppLogger.e(
                         "FavoritesRepository",
-                        "${Constants.ERROR} beim Konvertieren von Entity: ${e.message}"
+                        "Fehler beim Konvertieren von Entity: ${e.message}"
                     )
                     AppLogger.e(
                         "FavoritesRepository",
@@ -136,7 +135,7 @@ class FavoritesRepository @Inject constructor(
         } catch (e: Exception) {
             AppLogger.e(
                 "FavoritesRepository",
-                "${Constants.ERROR} beim Laden des Favoriten: ${e.message}"
+                "Fehler beim Laden des Favoriten: ${e.message}"
             )
             null
         }
@@ -217,7 +216,7 @@ class FavoritesRepository @Inject constructor(
         } catch (e: Exception) {
             AppLogger.e(
                 "FavoritesRepository",
-                "${Constants.ERROR} beim Hinzufügen des Favoriten: ${e.message}"
+                "Fehler beim Hinzufügen des Favoriten: ${e.message}"
             )
             Resource.Error("Fehler beim Hinzufügen zu Favoriten: " + e.localizedMessage)
         }
@@ -319,7 +318,7 @@ class FavoritesRepository @Inject constructor(
         } catch (e: Exception) {
             AppLogger.e(
                 "FavoritesRepository",
-                "${Constants.ERROR} beim Umschalten des Favoriten: ${e.message}"
+                "Fehler beim Umschalten des Favoriten: ${e.message}"
             )
             Resource.Error("Fehler beim Umschalten des Favoriten: " + e.localizedMessage)
         }
@@ -356,7 +355,7 @@ class FavoritesRepository @Inject constructor(
                 } catch (e: Exception) {
                     AppLogger.e(
                         "FavoritesRepository",
-                        "${Constants.ERROR} beim Konvertieren von Entity in Suche: ${e.message}"
+                        "Fehler beim Konvertieren von Entity in Suche: ${e.message}"
                     )
                     Game(
                         id = entity.id,

--- a/app/src/main/java/de/syntax_institut/androidabschlussprojekt/data/repositories/GamePagingSource.kt
+++ b/app/src/main/java/de/syntax_institut/androidabschlussprojekt/data/repositories/GamePagingSource.kt
@@ -2,7 +2,6 @@ package de.syntax_institut.androidabschlussprojekt.data.repositories
 
 import android.content.*
 import androidx.paging.*
-import de.syntax_institut.androidabschlussprojekt.data.*
 import de.syntax_institut.androidabschlussprojekt.data.local.dao.*
 import de.syntax_institut.androidabschlussprojekt.data.local.mapper.GameCacheMapper.toCacheEntity
 import de.syntax_institut.androidabschlussprojekt.data.local.mapper.GameCacheMapper.toGame
@@ -123,7 +122,7 @@ class GamePagingSource(
                 }
             }
         } catch (e: Exception) {
-            AppLogger.e("GameRepository", "${Constants.ERROR} beim API-Call in PagingSource", e)
+            AppLogger.e("GameRepository", "Fehler beim API-Call in PagingSource", e)
             // Fallback auf Cache bei Netzwerkfehler
             val cachedGames = gameCacheDao.getGamesByQueryAndFilter(query, filterHash).first()
             if (cachedGames.isNotEmpty()) {

--- a/app/src/main/java/de/syntax_institut/androidabschlussprojekt/ui/screens/DetailScreen.kt
+++ b/app/src/main/java/de/syntax_institut/androidabschlussprojekt/ui/screens/DetailScreen.kt
@@ -10,12 +10,13 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.*
 import androidx.compose.ui.platform.*
+import androidx.compose.ui.res.*
 import androidx.compose.ui.tooling.preview.*
 import androidx.compose.ui.unit.*
 import androidx.core.net.*
 import androidx.navigation.*
 import androidx.navigation.compose.*
-import de.syntax_institut.androidabschlussprojekt.data.*
+import de.syntax_institut.androidabschlussprojekt.R
 import de.syntax_institut.androidabschlussprojekt.data.local.models.*
 import de.syntax_institut.androidabschlussprojekt.ui.components.common.*
 import de.syntax_institut.androidabschlussprojekt.ui.components.detail.*
@@ -106,7 +107,7 @@ fun DetailScreen(
                     ) {
                         ErrorCard(
                             modifier = Modifier.padding(16.dp),
-                            error = res.message ?: Constants.ERROR_UNKNOWN,
+                            error = res.message ?: stringResource(R.string.error_unknown_default),
                         )
                         Spacer(modifier = Modifier.height(16.dp))
                         Button(

--- a/app/src/main/java/de/syntax_institut/androidabschlussprojekt/ui/screens/FavoritesScreen.kt
+++ b/app/src/main/java/de/syntax_institut/androidabschlussprojekt/ui/screens/FavoritesScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.ui.unit.*
 import androidx.navigation.*
 import androidx.navigation.compose.*
 import de.syntax_institut.androidabschlussprojekt.R
-import de.syntax_institut.androidabschlussprojekt.data.*
 import de.syntax_institut.androidabschlussprojekt.navigation.*
 import de.syntax_institut.androidabschlussprojekt.ui.components.common.*
 import de.syntax_institut.androidabschlussprojekt.ui.components.search.*
@@ -93,7 +92,7 @@ fun FavoritesScreen(
                 state.error != null -> {
                     ErrorCard(
                         modifier = Modifier.fillMaxSize(),
-                        error = state.error ?: Constants.ERROR_UNKNOWN,
+                        error = state.error ?: stringResource(R.string.error_unknown_default),
                     )
                 }
 

--- a/app/src/main/java/de/syntax_institut/androidabschlussprojekt/ui/screens/SearchScreen.kt
+++ b/app/src/main/java/de/syntax_institut/androidabschlussprojekt/ui/screens/SearchScreen.kt
@@ -17,7 +17,6 @@ import androidx.navigation.*
 import androidx.navigation.compose.*
 import androidx.paging.compose.*
 import de.syntax_institut.androidabschlussprojekt.R
-import de.syntax_institut.androidabschlussprojekt.data.*
 import de.syntax_institut.androidabschlussprojekt.navigation.*
 import de.syntax_institut.androidabschlussprojekt.ui.components.common.*
 import de.syntax_institut.androidabschlussprojekt.ui.components.search.*
@@ -137,7 +136,7 @@ fun SearchScreen(
             if (state.error != null) {
                 ErrorCard(
                     modifier = Modifier.fillMaxSize(),
-                    error = state.error ?: Constants.ERROR_UNKNOWN,
+                    error = state.error ?: stringResource(R.string.error_unknown_default),
                 )
             } else if (!state.hasSearched) {
                 EmptyState(

--- a/app/src/main/java/de/syntax_institut/androidabschlussprojekt/ui/viewmodels/DetailViewModel.kt
+++ b/app/src/main/java/de/syntax_institut/androidabschlussprojekt/ui/viewmodels/DetailViewModel.kt
@@ -1,7 +1,6 @@
 package de.syntax_institut.androidabschlussprojekt.ui.viewmodels
 
 import androidx.lifecycle.*
-import de.syntax_institut.androidabschlussprojekt.data.*
 import de.syntax_institut.androidabschlussprojekt.domain.usecase.*
 import de.syntax_institut.androidabschlussprojekt.ui.states.*
 import de.syntax_institut.androidabschlussprojekt.utils.*
@@ -48,7 +47,7 @@ class DetailViewModel(
                         }
                     }
 
-                    if ((game?.website.isNullOrBlank() == true && game?.screenshots.isNullOrEmpty() == true) && !forceReload) {
+                    if ((game?.website.isNullOrBlank() && game?.screenshots.isNullOrEmpty()) && !forceReload) {
                         loadDetail(id, forceReload = true)
                     } else if (game != null) {
                         _uiState.value =
@@ -65,7 +64,7 @@ class DetailViewModel(
                 is Resource.Error -> {
                     AppLogger.e("DetailViewModel", "Fehler beim Laden: ${gameResult.message}")
                     _uiState.value = DetailUiState(
-                        resource = Resource.Error(gameResult.message ?: Constants.ERROR),
+                        resource = Resource.Error(gameResult.message ?: "Unbekannter Fehler"),
                         error = gameResult.message
                     )
                 }

--- a/app/src/main/java/de/syntax_institut/androidabschlussprojekt/ui/viewmodels/SearchViewModel.kt
+++ b/app/src/main/java/de/syntax_institut/androidabschlussprojekt/ui/viewmodels/SearchViewModel.kt
@@ -81,7 +81,7 @@ class SearchViewModel(
                 } else {
                     _uiState.update { 
                         it.copy(
-                            platformsError = platformResponse.message ?: Constants.ERROR_UNKNOWN,
+                            platformsError = platformResponse.message ?: "Unbekannter Fehler",
                             isLoadingPlatforms = false
                         ) 
                     }
@@ -107,7 +107,7 @@ class SearchViewModel(
                 } else {
                     _uiState.update { 
                         it.copy(
-                            genresError = genreResponse.message ?: Constants.ERROR_UNKNOWN,
+                            genresError = genreResponse.message ?: "Unbekannter Fehler",
                             isLoadingGenres = false
                         ) 
                     }


### PR DESCRIPTION
This commit removes the general `ERROR` and `ERROR_UNKNOWN` constants from `Constants.kt` and replaces their usage with more specific string resources or hardcoded strings where appropriate.

**Key Changes:**

*   **`Constants.kt`:**
    *   Removed `ERROR` and `ERROR_UNKNOWN` constants.
*   **Error Handling in UI Screens:**
    *   `DetailScreen.kt`, `FavoritesScreen.kt`, `SearchScreen.kt`: Updated to use `stringResource(R.string.error_unknown_default)` for default error messages in `ErrorCard`.
*   **Error Logging:**
    *   Log messages in `FavoriteGameMapper.kt`, `FavoritesRepository.kt`, and `GamePagingSource.kt` now use hardcoded "Fehler" (Error) prefixes instead of the `Constants.ERROR`.
*   **ViewModel Error States:**
    *   `DetailViewModel.kt`, `SearchViewModel.kt`: Updated to use "Unbekannter Fehler" (Unknown error) as a fallback string for error messages in UI states.
*   **Instrumentation Tests:**
    *   `SearchPagingIntegrationTest.kt`, `DetailScreenTest.kt`: Updated assertions to look for "Fehler:" instead of `Constants.ERROR + ":"`.

This change aims to improve localization by allowing error messages to be translated and makes error handling more specific by removing overly generic constants.

## Zusammenfassung von Sourcery

Generische Fehlerkonstanten entfernen und die Lokalisierung von Fehlermeldungen verbessern, indem diese durch spezifische String-Ressourcen und Literale in der gesamten Codebasis ersetzt werden.

Verbesserungen:
- Ersetze generische Fehlerkonstanten durch lokalisierte String-Ressourcen und fest codierte deutsche Literale für UI-Fehlermeldungen und Log-Präfixe

Tests:
- Aktualisiere Instrumentierungs- und UI-Tests, um die Assertion gegen das neue Präfix "Fehler:" durchzuführen

Sonstiges:
- Entferne die Konstanten `ERROR` und `ERROR_UNKNOWN` aus `Constants.kt`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove generic error constants and enhance error message localization by replacing them with specific string resources and literals across the codebase.

Enhancements:
- Replace generic error constants with localized string resources and hardcoded German literals for UI error messages and log prefixes

Tests:
- Update instrumentation and UI tests to assert against the new "Fehler:" prefix

Chores:
- Remove `ERROR` and `ERROR_UNKNOWN` constants from `Constants.kt`

</details>